### PR TITLE
Fix format_profile return logic

### DIFF
--- a/src/famforge/models.py
+++ b/src/famforge/models.py
@@ -108,3 +108,5 @@ class Familiar(BaseModel):
             )
 
             return [panel]
+        else:
+            return lines


### PR DESCRIPTION
## Summary
- complete `format_profile` in `models.py`

## Testing
- `PYTHONPATH=src python -m famforge.main --help`
- `PYTHONPATH=src python - <<'PY'
from famforge.generator import generate_familiar
f=generate_familiar()
print('generated', f.name)
print('profile lines', len(f.format_profile()))
print(f.format_profile(rich=False))
PY`

------
https://chatgpt.com/codex/tasks/task_e_683f5729285483339ed55bdc677c7f77