### PR TITLE
Fix changelog typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to **FamForge** will be documented here.
 - Summoning experience now feels more magical and consistent, with no variation in display format.
 
 ### 🧼 Code Cleanup
-- Refactored data pools into managable JSON files (located in `src/famforge/data`)
+- Refactored data pools into manageable JSON files (located in `src/famforge/data`)
 - Removed all branching output logic — summoning always renders in a rich, single-panel style.
 - Streamlined `summon.py` for clarity and maintainability.
 - Centralized formatting logic into `format_profile()` with consistent return types.


### PR DESCRIPTION
## Summary
- fix `manageable` typo in CHANGELOG

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f5ea3264483338fe730fcf19c5956