### PR TITLE
Fix passphrase comments

### DIFF
--- a/src/famforge/incantation.py
+++ b/src/famforge/incantation.py
@@ -2,7 +2,7 @@ import hashlib
 import random
 from typing import List
 
-# Word banks for passphrase construction
+# Word banks for incantation construction
 ESSENCE_WORDS: List[str] = [
     "veil", "ember", "dusk", "spirit", "aether",
     "dream", "soul", "cinder", "echo", "shadow",

--- a/src/famforge/reveal.py
+++ b/src/famforge/reveal.py
@@ -10,7 +10,7 @@ app = typer.Typer(help="Reveal hidden truths about your familiars")
 
 GRIMOIRE_PATH = Path.home() / ".famforge" / "familiars.json"
 
-# Word banks for passphrase construction
+# Word banks for incantation construction
 ESSENCE_WORDS: List[str] = [
     "veil", "ember", "dusk", "spirit", "aether",
     "dream", "soul", "cinder", "echo", "shadow",

--- a/src/famforge/sigil.py
+++ b/src/famforge/sigil.py
@@ -9,7 +9,7 @@ app = typer.Typer(help="Render the sigil of a familiar", invoke_without_command=
 
 GRIMOIRE_PATH = Path.home() / ".famforge" / "familiars.json"
 
-# Word banks for passphrase construction
+# Word banks for incantation construction
 ESSENCE_WORDS: List[str] = [
     "veil", "ember", "dusk", "spirit", "aether",
     "dream", "soul", "cinder", "echo", "shadow",


### PR DESCRIPTION
## Summary
- update references to 'passphrase' in comments

## Testing
- `python -m compileall -q src/famforge`

------
https://chatgpt.com/codex/tasks/task_e_683f5e9ce4888333948186e772a2f98e